### PR TITLE
Only request certificate if necessary

### DIFF
--- a/haproxy/docker-entrypoint.d/10-tls-setup.sh
+++ b/haproxy/docker-entrypoint.d/10-tls-setup.sh
@@ -28,23 +28,26 @@ fi
 
 # Request certificate if not already available
 if [ ! -f ${HAPROXY_PEM_FILE} ]; then
-  # Wait for CA API to be available
-  while ! curl -k -s -f $CA_API_URL > /dev/null; do
-    echo "---> Waiting for CA API at ${CA_SERVER}..."
-    sleep 10
-  done
 
-  echo "---> Requesting certificate for ${CN} from ${CA_SERVER}"
-  su -s /bin/sh haproxy -c "/usr/bin/ruby \
-    /usr/local/bin/request-cert.rb \
-    --caserver ${CA_SERVER} \
-    --cn ${CN} \
-    --legacy ${USE_LEGACY_CA_API} \
-    --ssldir /usr/local/etc/haproxy/ssl"
+  if [[ ! -f ${CERTFILE} || ! -f ${KEYFILE} ]]; then
+    # Wait for CA API to be available
+    while ! curl -k -s -f $CA_API_URL > /dev/null; do
+        echo "---> Waiting for CA API at ${CA_SERVER}..."
+        sleep 10
+    done
 
-  if [ ! -f ${CERTFILE} ]; then
-    echo "---> Certificate retrieval failed. Exiting"
-    exit 1
+    echo "---> Requesting certificate for ${CN} from ${CA_SERVER}"
+    su -s /bin/sh haproxy -c "/usr/bin/ruby \
+        /usr/local/bin/request-cert.rb \
+        --caserver ${CA_SERVER} \
+        --cn ${CN} \
+        --legacy ${USE_LEGACY_CA_API} \
+        --ssldir /usr/local/etc/haproxy/ssl"
+
+    if [ ! -f ${CERTFILE} ]; then
+        echo "---> Certificate retrieval failed. Exiting"
+        exit 1
+    fi
   fi
 
   # Prepare certificate for HAProxy


### PR DESCRIPTION
The current implementation will generate a private_key and request a
certificate, even if both files already exists. This unnecessarily
breaks a use case when you want to reuse existing certificates without
concating them into a haproxy compatible format first.