### PR TITLE
Use correct url to check if ca api is available

### DIFF
--- a/puppetdb/docker-entrypoint.d/10-tls-setup.sh
+++ b/puppetdb/docker-entrypoint.d/10-tls-setup.sh
@@ -15,7 +15,7 @@ fi
 # Request certificate if not already available
 if [ ! -f ${CERTFILE} ]; then
   # Wait for CA API to be available
-  while ! curl -k -s -f https://${CA_SERVER}:8140/puppet-ca/v1/certificate/ca > /dev/null; do
+  while ! curl -k -s -f ${CA_API_URL} > /dev/null; do
     echo "---> Waiting for CA API at ${CA_SERVER}..."
     sleep 10
   done


### PR DESCRIPTION
The URL for the CA_API is dependent on the CA API version. The correct
information is already available in a variable so lets use it.