### PR TITLE
Converted all bash scripts' shebangs

### DIFF
--- a/cleanup-data.sh
+++ b/cleanup-data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 VOLUME_PREFIX=${VOLUME_PREFIX:-puppetindocker}
 volumes="
 ${VOLUME_PREFIX}_ca_data

--- a/haproxy/docker-entrypoint.d/10-tls-setup.sh
+++ b/haproxy/docker-entrypoint.d/10-tls-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CN=$(hostname)
 CA_SERVER=${CA_SERVER:-puppetca.local}

--- a/haproxy/docker-entrypoint.d/20-confd.sh
+++ b/haproxy/docker-entrypoint.d/20-confd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export STATS_CRED=${STATS_CRED:-"admin:password"}
 export PUPPETCA_BACKEND=${PUPPETCA_BACKEND:-puppetca.local}

--- a/haproxy/docker-entrypoint.sh
+++ b/haproxy/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 DIR=/docker-entrypoint.d

--- a/haproxy/request-cert.rb
+++ b/haproxy/request-cert.rb
@@ -1,4 +1,4 @@
-#!/bin/env ruby
+#!/usr/bin/env ruby
 require "net/http"
 require "resolv"
 require "fileutils"

--- a/mcoclient/docker-entrypoint.d/21-mcollective-config.sh
+++ b/mcoclient/docker-entrypoint.d/21-mcollective-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CA_SERVER=${CA_SERVER:-puppetca.local}
 MCOLLECTIVE_CERTNAME=${MCOLLECTIVE_CERTNAME:-deployer.mcollective}

--- a/mcoclient/docker-entrypoint.sh
+++ b/mcoclient/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 DIR=/docker-entrypoint.d

--- a/nats/docker-entrypoint.d/10-tls-setup.sh
+++ b/nats/docker-entrypoint.d/10-tls-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CN=$(hostname)
 CA_SERVER=${CA_SERVER:-puppetca.local}

--- a/nats/docker-entrypoint.d/20-nats-config.sh
+++ b/nats/docker-entrypoint.d/20-nats-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CN=$(hostname)
 CERTFILE="/etc/nats/ssl/certs/${CN}.pem"

--- a/nats/docker-entrypoint.sh
+++ b/nats/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 DIR=/docker-entrypoint.d

--- a/nats/request-cert.rb
+++ b/nats/request-cert.rb
@@ -1,4 +1,4 @@
-#!/bin/env ruby
+#!/usr/bin/env ruby
 require "net/http"
 require "resolv"
 require "fileutils"

--- a/postgres/docker-entrypoint-initdb.d/extensions.sh
+++ b/postgres/docker-entrypoint-initdb.d/extensions.sh
@@ -1,4 +1,4 @@
-#!/usr/bin.env bash
+#!/usr/bin/env bash
 
 set -x
 set -e

--- a/puppetdb/docker-entrypoint.d/10-tls-setup.sh
+++ b/puppetdb/docker-entrypoint.d/10-tls-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CN=$(hostname)
 CA_SERVER=${CA_SERVER:-puppetca.local}

--- a/puppetdb/docker-entrypoint.d/20-whitelist.sh
+++ b/puppetdb/docker-entrypoint.d/20-whitelist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "---> Configuring PuppetDB whitelist"
 if [ "$PUPPETDB_WHITELIST" ]; then

--- a/puppetdb/docker-entrypoint.sh
+++ b/puppetdb/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 DIR=/docker-entrypoint.d

--- a/puppetdb/request-cert.rb
+++ b/puppetdb/request-cert.rb
@@ -1,4 +1,4 @@
-#!/bin/env ruby
+#!/usr/bin/env ruby
 require "net/http"
 require "resolv"
 require "fileutils"

--- a/puppetexplorer/docker-entrypoint.d/20-nginx-config.sh
+++ b/puppetexplorer/docker-entrypoint.d/20-nginx-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PUPPETDB_SERVER=${PUPPETDB_SERVER:-puppetdb.local}
 

--- a/puppetexplorer/docker-entrypoint.sh
+++ b/puppetexplorer/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 DIR=/docker-entrypoint.d

--- a/puppetserver/docker-entrypoint.d/10-configure-ca.sh
+++ b/puppetserver/docker-entrypoint.d/10-configure-ca.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CN=$(hostname)
 CA_SERVER=${CA_SERVER:-puppetca.local}

--- a/puppetserver/docker-entrypoint.d/20-puppetdb.sh
+++ b/puppetserver/docker-entrypoint.d/20-puppetdb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CN=$(hostname)
 

--- a/puppetserver/docker-entrypoint.d/30-enc.sh
+++ b/puppetserver/docker-entrypoint.d/30-enc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -n "$PUPPET_ENC" ]; then
   echo "---> Configuring Puppetserver to use ENC ${PUPPET_ENC}"

--- a/puppetserver/docker-entrypoint.d/31-hiera.sh
+++ b/puppetserver/docker-entrypoint.d/31-hiera.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -n "$HIERA_BASE64" ]; then
   echo "---> Saving Hiera configuration to /etc/puppetlabs/puppet/hiera.yaml (base64 decoded)"

--- a/puppetserver/docker-entrypoint.d/40-external-tls-termination.sh
+++ b/puppetserver/docker-entrypoint.d/40-external-tls-termination.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "---> Configuring Puppetserver to accept SSL verification headers"
 sed -i 's/version: 1/version: 1\n    allow-header-cert-info: true/' /etc/puppetlabs/puppetserver/conf.d/auth.conf

--- a/puppetserver/docker-entrypoint.d/41-jruby-instances.sh
+++ b/puppetserver/docker-entrypoint.d/41-jruby-instances.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "---> Configuring JRUBY instances of Puppetserver"
 sed -i -E \

--- a/puppetserver/docker-entrypoint.d/50-disable-legacy-auth.sh
+++ b/puppetserver/docker-entrypoint.d/50-disable-legacy-auth.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Disable jruby-puppet.use-legacy-auth-conf
 # Suppresses the log message:

--- a/puppetserver/docker-entrypoint.d/99-generic-config.sh
+++ b/puppetserver/docker-entrypoint.d/99-generic-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 readonly config_re='^PUPPETCONF_([^_]+)_(.+)$'
 

--- a/puppetserver/docker-entrypoint.sh
+++ b/puppetserver/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 DIR=/docker-entrypoint.d

--- a/puppetserver/request-cert.rb
+++ b/puppetserver/request-cert.rb
@@ -1,4 +1,4 @@
-#!/bin/env ruby
+#!/usr/bin/env ruby
 require "net/http"
 require "resolv"
 require "fileutils"

--- a/r10k/docker-entrypoint.d/10-tls-setup.sh
+++ b/r10k/docker-entrypoint.d/10-tls-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CN=$(hostname)
 CA_SERVER=${CA_SERVER:-puppetca.local}

--- a/r10k/docker-entrypoint.d/20-r10k-config.sh
+++ b/r10k/docker-entrypoint.d/20-r10k-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -n "$R10K_REPO" ]; then
   echo "---> Configuring r10k repository: $R10K_REPO"

--- a/r10k/docker-entrypoint.d/21-mcollective-config.sh
+++ b/r10k/docker-entrypoint.d/21-mcollective-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CA_SERVER=${CA_SERVER:-puppetca.local}
 IDENTITY=$(hostname)

--- a/r10k/docker-entrypoint.sh
+++ b/r10k/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 DIR=/docker-entrypoint.d

--- a/r10k/request-cert.rb
+++ b/r10k/request-cert.rb
@@ -1,4 +1,4 @@
-#!/bin/env ruby
+#!/usr/bin/env ruby
 require "net/http"
 require "resolv"
 require "fileutils"


### PR DESCRIPTION
As the shebang of `postgres/docker-entrypoint-initdb.d/extensions.sh` was broken, I fixed it. While I was going at it, I also converted all the other bash scripts' shebangs to the `/usr/bin/env` style.

In the ruby scripts the shebang was pointing to `/bin/env`, which is not available in the ubuntu:16.04 docker image. Changed that to the real location at `/usr/bin/env`, too.