### PR TITLE
Manage PuppetDB maximum-pool-size database setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+## v2.4.0
+### Added
+- manage maximum-pool-size setting, default value 25
+
+### Changed
+- Update PuppetDB from 5.1.3 to 5.1.5
+
 ## v2.3.1
 ### Fixed
 - Fix gettext-setup issue, puppetlabs/SERVER-1912

--- a/puppetdb/Dockerfile
+++ b/puppetdb/Dockerfile
@@ -1,12 +1,13 @@
 FROM ubuntu:16.04
 
-ENV PUPPETDB_VERSION="5.1.3" \
+ENV PUPPETDB_VERSION="5.1.5" \
     DUMB_INIT_VERSION="1.2.1" \
     UBUNTU_CODENAME="xenial" \
     PUPPETDB_USER=puppetdb \
     PUPPETDB_PASSWORD=puppetdb \
     PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m" \
     PUPPETDB_NODETTL="30d" \
+    PUPPETDB_MAXPOOLSIZE=25 \
     PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
 
 LABEL org.label-schema.vendor="VSHN AG" \

--- a/puppetdb/README.md
+++ b/puppetdb/README.md
@@ -11,14 +11,15 @@ to be run in Docker.
 
 ### Environment variables
 
-| Name               | Description                                     | Default value  |
-| ----               | -----------------------------------------       | -------------  |
-| CA_SERVER          | Puppet CA server to request certificate         | puppetca.local |
-| POSTGRES_PASSWORD  | Password for Postgres user                      | -              |
-| POSTGRES_USER      | Username for Postgres connection                | -              |
-| USE_LEGACY_CA_API  | If set to true, sets CA API URLs for Puppet 3.8 | -              |
-| PUPPETDB_NODETTL   | PuppetDB node-ttl (default was 7d)              | 30d            |
-| PUPPETDB_WHITELIST | Set to `true` to enable puppetdb whitelist      | - (false)      |
+| Name                 | Description                                     | Default value  |
+| ----                 | -----------------------------------------       | -------------  |
+| CA_SERVER            | Puppet CA server to request certificate         | puppetca.local |
+| POSTGRES_PASSWORD    | Password for Postgres user                      | -              |
+| POSTGRES_USER        | Username for Postgres connection                | -              |
+| USE_LEGACY_CA_API    | If set to true, sets CA API URLs for Puppet 3.8 | -              |
+| PUPPETDB_NODETTL     | PuppetDB node-ttl (default was 7d)              | 30d            |
+| PUPPETDB_WHITELIST   | Set to `true` to enable puppetdb whitelist      | - (false)      |
+| PUPPETDB_MAXPOOLSIZE | maximum-pool-size database setting              | 25             |
 
 ### PuppetDB Certificate Whitelist
 By default any valid certificate from the CA can query anything that's in the PuppetDB.

--- a/puppetdb/conf.d/database.conf
+++ b/puppetdb/conf.d/database.conf
@@ -3,4 +3,5 @@ database: {
   username: ${PUPPETDB_USER}
   password: ${PUPPETDB_PASSWORD}
   node-ttl: ${PUPPETDB_NODETTL}
+  maximum-pool-size: ${PUPPETDB_MAXPOOLSIZE}
 }


### PR DESCRIPTION
Now the maximum-pool-size database setting can be managed via
env variables.

Also use the current PuppetDB version 5.1.5.